### PR TITLE
Make else clause optional

### DIFF
--- a/private/new-version-case.rkt
+++ b/private/new-version-case.rkt
@@ -42,7 +42,7 @@
      (syntax/loc stx
        (version-case [test code ...]
                      ...
-                     [else]))]
+                     [else (void)]))]
     [else
      (raise-syntax-error 
       #f 

--- a/private/new-version-case.rkt
+++ b/private/new-version-case.rkt
@@ -38,6 +38,11 @@
             (begin
               (define-syntax name transformer)
               (name)))]))]
+    [(_ [test code ...] ...)
+     (syntax/loc stx
+       (version-case [test code ...]
+                     ...
+                     [else]))]
     [else
      (raise-syntax-error 
       #f 

--- a/test-version-case.rkt
+++ b/test-version-case.rkt
@@ -10,6 +10,8 @@
                                 "360"]
                                [else
                                 "something else"]))
+  (printf "~s~n" (version-case [(version= (version) "360")
+                                "360"]))
 
 
   ;; Ellipses should work in a version case.

--- a/test-version-case.rkt
+++ b/test-version-case.rkt
@@ -50,4 +50,33 @@
       (define (phase1)
         (message-box "phase1"))
       (define (phase2)
+        (message-box "phase2")))])
+
+  (version-case
+   [(version<= (version) "360")
+    (printf "old unit code (no else form)~n")
+    (require (lib "mred.ss" "mred")
+             (lib "tool.ss" "drscheme")
+             (lib "unitsig.ss"))
+
+    (define tool2@
+      (unit/sig drscheme:tool-exports^
+          (import drscheme:tool^)
+        (define (phase1)
+          (message-box "phase1"))
+        (define (phase2)
+          (message-box "phase2"))))])
+
+  (version-case
+   [(version> (version) "360")
+    (printf "new unit code (no else form)~n")
+    (require scheme/gui/base
+             (lib "tool.ss" "drscheme")
+             (lib "unit.ss"))
+    (define-unit tool2@
+      (import drscheme:tool^)
+      (export drscheme:tool-exports^)
+      (define (phase1)
+        (message-box "phase1"))
+      (define (phase2)
         (message-box "phase2")))]))


### PR DESCRIPTION
Hello,
Thank you for maintaining this useful package. Lately I've needed to do:

```
(version-case
 [(version< (version) "7.9.0.22")
  (define-alias define-syntax-parse-rule define-simple-macro)])
```
but I noticed that `version-case` expects an else clause, necessitating:
```
(version-case
 [(version< (version) "7.9.0.22")
  (define-alias define-syntax-parse-rule define-simple-macro)]
 [else])
```

I took a look and added support for leaving out the `else` clause. I'm not too familiar with the use of `syntax-case` and `syntax/loc`, but the code appears to work. Re: tests, I don't know what the existing tests refer to, but I assume they represent functionality that prove a compile-time difference between version "360" and subsequent versions, so I retained them verbatim in the new tests that simply exclude the else clause.
